### PR TITLE
Prevent page-scrolling, and (attempt to) vertically middle-align the arrow

### DIFF
--- a/public/static/style.css
+++ b/public/static/style.css
@@ -3,9 +3,6 @@
 	padding: 0;
 	box-sizing: border-box;
 }
-html, body {
-	height: 100%;
-}
 body {
 	background: #232345;
 	margin: auto;
@@ -29,6 +26,18 @@ a, a:visited, a:active {
 	width: 100%;
 	height: 100%;
 	text-align: center;
+	position: fixed;
+	top: 0;
+	left: 0;
+	margin-top: 265px;
+	pointer-events: none;
+}
+.direction:before {
+	position: absolute;
+	top: 50%;
+	left: 0;
+	margin-top: -1.12em;
+	width: 100%;
 }
 .forward, .back, .left, .right {
 	background: #6aae49;


### PR DESCRIPTION
I changed the direction element to fixed position with 100% height minus a margin-top so that it covers exactly the full page minus the space for the instructions text.  In addition to removing the 100% height on body/html, this removes vertical scrolling on the page (at least for typical desktop browser window sizes).

I also tried to vertically middle-align the arrows using position absolute with a reverse margin-top.  This doesn't fully succeed, as the arrows are all different visible heights.  I suppose having a different margin-top for each of the different arrow directions would work, but... that seems like overkill.
